### PR TITLE
Eag 2099 searching and accessing categories concurrently may throw an error

### DIFF
--- a/src/main/scala/ae/teletronics/nlp/categorisation/storage/TopicStore.scala
+++ b/src/main/scala/ae/teletronics/nlp/categorisation/storage/TopicStore.scala
@@ -2,14 +2,15 @@ package ae.teletronics.nlp.categorisation.storage
 
 import ae.teletronics.nlp.categorisation.Category
 import org.apache.commons.lang3.SerializationUtils
-import org.mapdb.{DBMaker, HTreeMap, Serializer}
+import org.mapdb.{DB, DBMaker, HTreeMap, Serializer}
 import java.util.UUID
+import java.nio.file.{Files, Paths}
+
 import scala.collection.JavaConversions._
 
-
 /**
-  * Created by trym on 26-09-2016.
-  */
+* Created by trym on 26-09-2016.
+*/
 class TopicStore(dbFileName: String) {
 
   def create(name: String): Category = create(name, List())
@@ -17,13 +18,13 @@ class TopicStore(dbFileName: String) {
   def create(name: String, entries: List[String]): Category = create(new Category(name, UUID.randomUUID(), entries))
 
   def create(t: Category): Category = deserialize(categories(map =>
-    if (map.contains(t.id))
-      throw new Exception("Cannot create category, id already exists: " + t.id)
-    else {
-      val value = serialize(t)
-      map.put(t.id, value)
-      value // put doesnt return the value, so have to return it explicitly
-    }))
+  if (map.contains(t.id))
+    throw new Exception("Cannot create category, id already exists: " + t.id)
+  else {
+    val value = serialize(t)
+    map.put(t.id, value)
+    value // put doesnt return the value, so have to return it explicitly
+  }))
 
   def delete(id: UUID): Category = deserialize(categories(_.remove(id)))
 
@@ -31,26 +32,60 @@ class TopicStore(dbFileName: String) {
 
   def update(topic: Category): Category = deserialize(categories(_.replace(topic.id, serialize(topic))))
 
-  def list(): List[Category] = {
-    import scala.collection.JavaConversions._
-    categories(_.getValues().toList)
-      .map(deserialize)
+  // useful for testing purposes
+  def clearAll(): Unit = {
+    categories(_.clear())
   }
 
-  private def categories[T](action: HTreeMap[UUID, Array[Byte]] => T): T = {
-  val db = DBMaker.fileDB(dbFileName).make
-  val topics: HTreeMap[UUID, Array[Byte]] = db.hashMap("topics")
-    .keySerializer(Serializer.UUID)
-    .valueSerializer(Serializer.BYTE_ARRAY)
-    .createOrOpen()
+  def list(): List[Category] = {
+  import scala.collection.JavaConversions._
+  categories(_.getValues().toList)
+    .map(deserialize)
+  }
 
-    try {
-      action(topics)
-    } finally {
-      db.close()
-    }
+  def categories[T](action: HTreeMap[UUID, Array[Byte]] => T): T = {
+    TopicStore.commitOnTopicsInDb(dbFileName, action)
   }
 
   private def serialize(t: Category): Array[Byte] = if (t != null) SerializationUtils.serialize(t) else null
   private def deserialize(bytes: Array[Byte]): Category = if (bytes != null) SerializationUtils.deserialize(bytes) else null
+}
+
+object TopicStore {
+
+  private var fileDbsMap: Map[String, DB] = Map[String, DB]()
+
+  def commitOnTopicsInDb[T](dbFileName: String, action: HTreeMap[UUID, Array[Byte]] => T): T = {
+    this.synchronized {
+      val db = dbForFile(dbFileName)
+      val topics: HTreeMap[UUID, Array[Byte]] = db.hashMap("topics")
+        .keySerializer(Serializer.UUID)
+        .valueSerializer(Serializer.BYTE_ARRAY)
+        .createOrOpen()
+
+      val result = action(topics)
+      db.commit()
+      result
+    }
+  }
+
+  private def dbForFile(file: String): DB = {
+    this.synchronized {
+      val mapContains = fileDbsMap.containsKey(file)
+      val fileExists = Files.exists(Paths.get(file))
+      if (mapContains && fileExists) {
+        // all is good
+        return fileDbsMap(file)
+      } else if (!mapContains) {
+        // When we start the service. The file may exist from a previous run.
+        val db = DBMaker.fileDB(file)
+          .make()
+        this.fileDbsMap = this.fileDbsMap + (file -> db)
+        return db
+      } else {
+        // we have the DB object in memory, but the backing file is missing. This is an error state
+        throw new Exception("Missing MapDb file: " + file)
+      }
+    }
+  }
 }

--- a/src/main/scala/ae/teletronics/nlp/categorisation/storage/TopicStore.scala
+++ b/src/main/scala/ae/teletronics/nlp/categorisation/storage/TopicStore.scala
@@ -87,34 +87,30 @@ object TopicStore {
   }
 
   private def readCacheForFile(dbFileName: String): Map[UUID, Array[Byte]] = {
-    this.synchronized {
-      val db = dbForFile(dbFileName)
-      val topics: HTreeMap[UUID, Array[Byte]] = db.hashMap("topics")
-        .keySerializer(Serializer.UUID)
-        .valueSerializer(Serializer.BYTE_ARRAY)
-        .createOrOpen()
+    val db = dbForFile(dbFileName)
+    val topics: HTreeMap[UUID, Array[Byte]] = db.hashMap("topics")
+      .keySerializer(Serializer.UUID)
+      .valueSerializer(Serializer.BYTE_ARRAY)
+      .createOrOpen()
 
-      topics.toMap
-    }
+    topics.toMap
   }
 
   private def dbForFile(dbFileName: String): DB = {
-    this.synchronized {
-      val mapContains = fileDbsMap.containsKey(dbFileName)
-      val fileExists = Files.exists(Paths.get(dbFileName))
-      if (mapContains && fileExists) {
-        // all is good
-        return fileDbsMap(dbFileName)
-      } else if (!mapContains) {
-        // When we start the service. The file may exist from a previous run.
-        val db = DBMaker.fileDB(dbFileName)
-          .make()
-        this.fileDbsMap = this.fileDbsMap + (dbFileName -> db)
-        return db
-      } else {
-        // we have the DB object in memory, but the backing file is missing. This is an error state
-        throw new Exception("Missing MapDb file: " + dbFileName)
-      }
+    val mapContains = fileDbsMap.containsKey(dbFileName)
+    val fileExists = Files.exists(Paths.get(dbFileName))
+    if (mapContains && fileExists) {
+      // all is good
+      return fileDbsMap(dbFileName)
+    } else if (!mapContains) {
+      // When we start the service. The file may exist from a previous run.
+      val db = DBMaker.fileDB(dbFileName)
+        .make()
+      this.fileDbsMap = this.fileDbsMap + (dbFileName -> db)
+      return db
+    } else {
+      // we have the DB object in memory, but the backing file is missing. This is an error state
+      throw new Exception("Missing MapDb file: " + dbFileName)
     }
   }
 }

--- a/src/test/scala/ae/teletronics/nlp/categorisation/FuzzyCategoriserTest.scala
+++ b/src/test/scala/ae/teletronics/nlp/categorisation/FuzzyCategoriserTest.scala
@@ -5,7 +5,6 @@ package ae.teletronics.nlp.categorisation
   */
 
 import java.io.File
-import java.nio.file.{Files, Paths}
 import java.util
 import java.util.UUID
 import org.junit._
@@ -21,9 +20,14 @@ class FuzzyCategoriserTest {
   private val storageFile = "target/storage-test.db"
   private val dummyUUID = new UUID(1L, 1L)
 
+  @Before
+  def beforeTest(): Unit = {
+    topicStore().clearAll()
+  }
+
   @After
   def afterTest(): Unit = {
-    Files.deleteIfExists(Paths.get(storageFile))
+    topicStore().clearAll()
   }
 
   @Test
@@ -108,10 +112,14 @@ class FuzzyCategoriserTest {
     assertThat(matchesForEntryInCategory(result, drugs.name, "heroin")(0), is("Heroin"))
   }
 
-  def seededTopicStore(categories: List[Category]): TopicStore = {
+  def topicStore(): TopicStore = {
     val storage = storageFile
     new File(storage).getParentFile().mkdirs() // ensure path exists
-    val ts = new TopicStore(storage)
+    new TopicStore(storage)
+  }
+
+  def seededTopicStore(categories: List[Category]): TopicStore = {
+    val ts = topicStore()
     categories.foreach(cat => ts.create(cat.name, cat.entries.toList))
     ts
   }

--- a/src/test/scala/ae/teletronics/nlp/categorisation/RegexCategoriserTest.scala
+++ b/src/test/scala/ae/teletronics/nlp/categorisation/RegexCategoriserTest.scala
@@ -22,9 +22,14 @@ class RegexCategoriserTest {
   private val storageFile = "target/storage-test.db"
   private val dummyUUID = new UUID(1L, 1L)
 
+  @Before
+  def beforeTest(): Unit = {
+    topicStore().clearAll()
+  }
+
   @After
   def afterTest(): Unit = {
-    Files.deleteIfExists(Paths.get(storageFile))
+    topicStore().clearAll()
   }
 
   @Test
@@ -94,10 +99,14 @@ class RegexCategoriserTest {
     categoryMatches.map(_.categoryName)
   }
 
-  def seededTopicStore(categories: List[Category]): TopicStore = {
+  def topicStore(): TopicStore = {
     val storage = storageFile
     new File(storage).getParentFile().mkdirs() // ensure path exists
-    val ts = new TopicStore(storage)
+    new TopicStore(storage)
+  }
+
+  def seededTopicStore(categories: List[Category]): TopicStore = {
+    val ts = topicStore()
     categories.foreach(cat => ts.create(cat.name, cat.entries.toList))
     ts
   }

--- a/src/test/scala/ae/teletronics/nlp/categorisation/StrictCategoriserTest.scala
+++ b/src/test/scala/ae/teletronics/nlp/categorisation/StrictCategoriserTest.scala
@@ -22,9 +22,14 @@ class StrictCategoriserTest {
   private val storageFile = "target/storage-test.db"
   private val dummyUUID = new UUID(1L, 1L)
 
+  @Before
+  def beforeTest(): Unit = {
+    topicStore().clearAll()
+  }
+
   @After
   def afterTest(): Unit = {
-    Files.deleteIfExists(Paths.get(storageFile))
+    topicStore().clearAll()
   }
 
   @Test
@@ -118,10 +123,14 @@ class StrictCategoriserTest {
     categoryMatches.map(_.categoryName)
   }
 
-  def seededTopicStore(categories: List[Category]): TopicStore = {
+  def topicStore(): TopicStore = {
     val storage = storageFile
     new File(storage).getParentFile().mkdirs() // ensure path exists
-    val ts = new TopicStore(storage)
+    new TopicStore(storage)
+  }
+
+  def seededTopicStore(categories: List[Category]): TopicStore = {
+    val ts = topicStore()
     categories.foreach(cat => ts.create(cat.name, cat.entries.toList))
     ts
   }

--- a/src/test/scala/ae/teletronics/nlp/categorisation/storage/TopicStoreTest.scala
+++ b/src/test/scala/ae/teletronics/nlp/categorisation/storage/TopicStoreTest.scala
@@ -15,24 +15,24 @@ import org.junit.{After, Before, Test}
 class TopicStoreTest {
 
   private val storageFile = "target/storage-test.db"
-  private val underTest = new TopicStore(storageFile)
   private val key = new UUID(1L, 1L)
   private val name = "topic"
   private val emptyEntries = util.Arrays.asList[String]()
   private val newCategory = new Category(name, UUID.randomUUID(), emptyEntries)
 
-  @After
-  def afterTest(): Unit = {
-    Files.deleteIfExists(Paths.get(storageFile))
-  }
-
   @Before
   def beforeTest(): Unit = {
-    new File(storageFile).getParentFile().mkdirs() // ensure path exists
+    topicStore().clearAll()
+  }
+
+  @After
+  def afterTest(): Unit = {
+    topicStore().clearAll()
   }
 
   @Test(expected = classOf[Exception])
   def testCreate(): Unit = {
+    val underTest = topicStore()
     assertNotNull(underTest.create(newCategory))
     // throw exception if we try to create another category with the same id
     underTest.create(newCategory)
@@ -40,6 +40,7 @@ class TopicStoreTest {
 
   @Test
   def testGet(): Unit = {
+    val underTest = topicStore()
     // start state
     underTest.create(newCategory)
     // action
@@ -50,6 +51,7 @@ class TopicStoreTest {
 
   @Test
   def testList(): Unit = {
+    val underTest = topicStore()
     // start state
     underTest.create(name)
     // action
@@ -59,6 +61,7 @@ class TopicStoreTest {
 
   @Test
   def testUpdate(): Unit = {
+    val underTest = topicStore()
     // start state
     underTest.create(newCategory)
     assertNotNull(underTest.get(newCategory.id))
@@ -69,6 +72,7 @@ class TopicStoreTest {
 
   @Test
   def testDelete(): Unit = {
+    val underTest = topicStore()
     // start state
     underTest.create(newCategory)
     // action
@@ -76,5 +80,11 @@ class TopicStoreTest {
     // verify
     assertNotNull(underTest.list())
     assertEquals(0, underTest.list().size)
+  }
+
+  def topicStore(): TopicStore = {
+    val storage = storageFile
+    new File(storage).getParentFile().mkdirs() // ensure path exists
+    new TopicStore(storage)
   }
 }


### PR DESCRIPTION
- Solve problem where concurrent access to the categories backend file could cause an error
- Cache the categories database, for better performance.